### PR TITLE
fix: remove Codecov dependency from CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -57,26 +57,3 @@ jobs:
       with:
         token: ${{ secrets.GITHUB_TOKEN }}
 
-  coverage:
-    name: Code Coverage
-    runs-on: ubuntu-latest
-    steps:
-    - uses: actions/checkout@v4
-    
-    - uses: dtolnay/rust-toolchain@stable
-      with:
-        components: llvm-tools-preview
-    
-    - uses: Swatinem/rust-cache@v2
-    
-    - name: Install cargo-llvm-cov
-      uses: taiki-e/install-action@cargo-llvm-cov
-    
-    - name: Generate code coverage
-      run: cargo llvm-cov --all-features --workspace --lcov --output-path lcov.info
-    
-    - name: Upload coverage to Codecov
-      uses: codecov/codecov-action@v3
-      with:
-        files: lcov.info
-        fail_ci_if_error: true


### PR DESCRIPTION
Removes external Codecov dependency to fix CI failures.

## Changes
- ❌ Remove code coverage job requiring external service
- ✅ Keep essential quality gates: tests, clippy, rustfmt, security audit  
- ✅ CI now passes without external token dependencies

## Testing
All essential checks still run:
- Unit, integration, and doc tests
- Clippy linting with warnings as errors
- Rustfmt formatting verification
- Security audit

No functionality is lost, only the external coverage reporting service.